### PR TITLE
extraneous mipmap generation prune

### DIFF
--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -326,7 +326,7 @@ void GBitmap::allocateBitmap(const U32 in_width, const U32 in_height, const bool
 
          mNumMipLevels++;
          allocPixels += currWidth * currHeight * mBytesPerPixel;
-      } while (currWidth != 1 || currHeight != 1);
+      } while (currWidth != 1 && currHeight != 1);
    }
    AssertFatal(mNumMipLevels <= c_maxMipLevels, "GBitmap::allocateBitmap: too many miplevels");
 

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1098,7 +1098,7 @@ void GFXTextureManager::_validateTexParams( const U32 width, const U32 height,
                currHeight = 1;
 
             inOutNumMips++;
-         } while ( currWidth != 1 || currHeight != 1 );
+         } while ( currWidth != 1 && currHeight != 1 );
       }
    }
 }


### PR DESCRIPTION
OR spits out quite a few pointless mips for non square textures, which can lead to it triggering that AssertFatal(mNumMipLevels <= c_maxMipLevels, "GBitmap::allocateBitmap: too many miplevels"); entry